### PR TITLE
Handle EOFError to allow exit with Ctrl-D

### DIFF
--- a/src/kurage/__init__.py
+++ b/src/kurage/__init__.py
@@ -86,9 +86,12 @@ def main():
     )
     while True:
         print("\nUser:\n")
-        user_input = prompt(
-            "  | ", key_bindings=kb, multiline=True, prompt_continuation="  | "
-        )
+        try:
+            user_input = prompt(
+                "  | ", key_bindings=kb, multiline=True, prompt_continuation="  | "
+            )
+        except EOFError:
+            break
         texts.append(user_input)
         system, messages = construct_system_and_messages(
             texts, system_prompt, character_setting


### PR DESCRIPTION
Catch EOFError to allow users to exit the program by pressing Ctrl-D.