### PR TITLE
refactor: Remove `.env` from `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,5 +8,3 @@ wheels/
 
 # Virtual environments
 .venv
-
-.env


### PR DESCRIPTION
`.env` is no longer used.

ref: gh-31