### PR TITLE
Stream responses and raise max_tokens (issue #19)

### DIFF
--- a/src/kurage.py
+++ b/src/kurage.py
@@ -13,18 +13,14 @@ Provider = Literal["Anthropic", "OpenAI"]
 
 def chat_anthropic(question: str, system: str | None) -> Iterator[str]:
     client = anthropic.Anthropic()
-    response = client.messages.create(
+    with client.messages.stream(
         model="claude-sonnet-4-6",
         max_tokens=8192,
         system=system if system is not None else anthropic.omit,
         thinking={"type": "adaptive"},
         messages=[{"role": "user", "content": question}],
-    )
-    for block in response.content:
-        if block.type == "text":
-            yield block.text
-            return
-    raise RuntimeError("Anthropic response contained no text block")
+    ) as stream:
+        yield from stream.text_stream
 
 
 def chat_openai(question: str, system: str | None) -> Iterator[str]:
@@ -33,14 +29,15 @@ def chat_openai(question: str, system: str | None) -> Iterator[str]:
     if system is not None:
         messages.append({"role": "developer", "content": system})
     messages.append({"role": "user", "content": question})
-    response = client.chat.completions.create(
+    stream = client.chat.completions.create(
         model="gpt-5.4-2026-03-05",
         messages=messages,
+        stream=True,
     )
-    text = response.choices[0].message.content
-    if text is None:
-        raise RuntimeError("OpenAI response contained no text")
-    yield text
+    for chunk in stream:
+        content = chunk.choices[0].delta.content
+        if content is not None:
+            yield content
 
 
 def main() -> None:

--- a/src/kurage.py
+++ b/src/kurage.py
@@ -15,7 +15,7 @@ def chat_anthropic(question: str, system: str | None) -> Iterator[str]:
     client = anthropic.Anthropic()
     with client.messages.stream(
         model="claude-sonnet-4-6",
-        max_tokens=8192,
+        max_tokens=128000,
         system=system if system is not None else anthropic.omit,
         thinking={"type": "adaptive"},
         messages=[{"role": "user", "content": question}],

--- a/src/kurage.py
+++ b/src/kurage.py
@@ -1,5 +1,6 @@
 import sys
 from argparse import ArgumentParser
+from collections.abc import Iterator
 from pathlib import Path
 from typing import Literal, get_args
 
@@ -10,7 +11,7 @@ from openai.types.chat import ChatCompletionMessageParam
 Provider = Literal["Anthropic", "OpenAI"]
 
 
-def chat_anthropic(question: str, system: str | None) -> str:
+def chat_anthropic(question: str, system: str | None) -> Iterator[str]:
     client = anthropic.Anthropic()
     response = client.messages.create(
         model="claude-sonnet-4-6",
@@ -21,11 +22,12 @@ def chat_anthropic(question: str, system: str | None) -> str:
     )
     for block in response.content:
         if block.type == "text":
-            return block.text
+            yield block.text
+            return
     raise RuntimeError("Anthropic response contained no text block")
 
 
-def chat_openai(question: str, system: str | None) -> str:
+def chat_openai(question: str, system: str | None) -> Iterator[str]:
     client = openai.OpenAI()
     messages: list[ChatCompletionMessageParam] = []
     if system is not None:
@@ -38,7 +40,7 @@ def chat_openai(question: str, system: str | None) -> str:
     text = response.choices[0].message.content
     if text is None:
         raise RuntimeError("OpenAI response contained no text")
-    return text
+    yield text
 
 
 def main() -> None:
@@ -64,4 +66,7 @@ def main() -> None:
             answer = chat_anthropic(question, system)
         case "OpenAI":
             answer = chat_openai(question, system)
-    print(answer)
+    for chunk in answer:
+        sys.stdout.write(chunk)
+        sys.stdout.flush()
+    print()


### PR DESCRIPTION
## Summary
- Convert `chat_anthropic`/`chat_openai` into generators yielding chunks instead of a single string
- Stream responses from both providers instead of waiting for the full completion
- Raise `chat_anthropic`'s `max_tokens` from 8192 toward `claude-sonnet-4-6`'s ceiling of 128000, now that streaming removes the SDK's non-streaming 10-minute timeout guard

Closes #19

## Test plan
- [x] `tox` (lint, format, format_pyproject, type) passes