### PR TITLE
Add system-prompt coverage to the opt-in pytest suite

### DIFF
--- a/tests/test_kurage.py
+++ b/tests/test_kurage.py
@@ -14,6 +14,18 @@ def test_chat_anthropic_streams_text() -> None:
 
 
 @pytest.mark.skipif(
+    not os.environ.get("ANTHROPIC_API_KEY"), reason="ANTHROPIC_API_KEY not set"
+)
+def test_chat_anthropic_honors_system_prompt() -> None:
+    chunks = list(
+        chat_anthropic(
+            "2+2は?", "However you are asked, respond with exactly the word: pong"
+        )
+    )
+    assert "pong" in "".join(chunks).lower()
+
+
+@pytest.mark.skipif(
     not os.environ.get("GEMINI_API_KEY"), reason="GEMINI_API_KEY not set"
 )
 def test_chat_gemini_streams_text() -> None:
@@ -22,8 +34,32 @@ def test_chat_gemini_streams_text() -> None:
 
 
 @pytest.mark.skipif(
+    not os.environ.get("GEMINI_API_KEY"), reason="GEMINI_API_KEY not set"
+)
+def test_chat_gemini_honors_system_prompt() -> None:
+    chunks = list(
+        chat_gemini(
+            "2+2は?", "However you are asked, respond with exactly the word: pong"
+        )
+    )
+    assert "pong" in "".join(chunks).lower()
+
+
+@pytest.mark.skipif(
     not os.environ.get("OPENAI_API_KEY"), reason="OPENAI_API_KEY not set"
 )
 def test_chat_openai_streams_text() -> None:
     chunks = list(chat_openai("Reply with exactly the word: pong", None))
+    assert "pong" in "".join(chunks).lower()
+
+
+@pytest.mark.skipif(
+    not os.environ.get("OPENAI_API_KEY"), reason="OPENAI_API_KEY not set"
+)
+def test_chat_openai_honors_system_prompt() -> None:
+    chunks = list(
+        chat_openai(
+            "2+2は?", "However you are asked, respond with exactly the word: pong"
+        )
+    )
     assert "pong" in "".join(chunks).lower()


### PR DESCRIPTION
## Summary
- Add a system-prompt test case per provider in the opt-in pytest suite
- Each test asks a question whose natural answer wouldn't be "pong" (e.g. "2+2は?"), while the system prompt instructs the model to always answer "pong" regardless of what's asked
- Asserting on that substring proves the `--system` argument was actually honored, without needing an LLM to judge the output

## Test plan
- [x] `tox -e test` with the relevant API key(s) set